### PR TITLE
Cleanup Teams app manifest

### DIFF
--- a/microsoft-teams/App Manifests/README.md
+++ b/microsoft-teams/App Manifests/README.md
@@ -74,7 +74,7 @@ The **configurationUrl** attribute value must be updated to include the host nam
 ```json
 "configurableTabs": [
         {
-            "configurationUrl": "https://{Connections_Hostname}/teams-tab",
+            "configurationUrl": "https://%Connections_Hostname%/teams-tab",
             "canUpdateConfiguration": true,
             "scopes": [
                 "team",
@@ -88,12 +88,12 @@ The **configurationUrl** attribute value must be updated to include the host nam
 ## Section 3 - Configuring Bots
 A bot is used to insert message content into a conversation on behalf of an application. In this case, the messaging extension, described in [section 4](#section-4---configuring-messaging-extensions), requires a bot to insert a card into the conversation with a link to Connections content.
 
-The botId/applicationId is generated when the bot is registered; see [Configuring an Azure App to Support the Microsoft Teams App]() in the Connections documentation. Use that id value to replace {Connections_AzureApplicationId}.
+The botId/applicationId is generated when the bot is registered; see [Configuring an Azure App to Support the Microsoft Teams App]() in the Connections documentation. Use that id value to replace %Connections_AzureApplicationId%.
 
 ```json
 "bots": [
    {
-      "botId": "{Connections_AzureApplicationId}",
+      "botId": "%Connections_AzureApplicationId%",
       "scopes": [
         "team"
       ],
@@ -111,14 +111,14 @@ The messaging extension allows an end user to invoke the Connections app integra
 Figure 3: Link to Content in Conversation
 <br>
 
-The **url** attribute value must be updated to include the host name at which Connections is accessed by replacing {Connections_Hostname}.
+The **url** attribute value must be updated to include the host name at which Connections is accessed by replacing %Connections_Hostname%.
 
-The botId/applicationId is generated when the bot is registered; see [Configuring an Azure App to Support the Microsoft Teams App]() in the Connections documentation. Use that id value to replace {Connections_AzureApplicationId}.
+The botId/applicationId is generated when the bot is registered; see [Configuring an Azure App to Support the Microsoft Teams App]() in the Connections documentation. Use that id value to replace %Connections_AzureApplicationId%.
 
 ```json
 "composeExtensions": [
    {
-      "botId": "{Connections_AzureApplicationId}",
+      "botId": "%Connections_AzureApplicationId%",
       "canUpdateConfiguration": true,
       "commands": [
          {
@@ -144,7 +144,7 @@ The botId/applicationId is generated when the bot is registered; see [Configurin
                "title": "Connections Share",
                "width": "medium",
                "height": "medium",
-               "url": "https://{Connections_Hostname}/teams-share-service/api/msteams/command"
+               "url": "https://%Connections_Hostname%/teams-share-service/api/msteams/command"
             }
          }
       ]
@@ -158,11 +158,11 @@ See [section 7](#section-7---configuring-localization) for details on translatio
 ## Section 5 - Configuring Domains
 Valid domains identifies a list of target host or domain names for websites that Teams should allow access from within the Teams browser or client experience. For example, the tab app will show Connections content pages, so the host name or domain of the Connections deployment must be allowed. 
 
-Replace the {Connections_Hostname} value in the json array with either the full Connections host name or appropriate domain name.
+Replace the %Connections_Hostname% value in the json array with either the full Connections host name or appropriate domain name.
 
 ```json
 "validDomains": [
-   "{Connections_Hostname}"
+   "%Connections_Hostname%"
 ],
 ```
 <br>
@@ -172,7 +172,7 @@ Replace the correct app id and resource url values to allow SSO to work with the
 ```json
 "webApplicationInfo": {
    "id": "{Connections_AzureApplicationId}",
-   "resource": "api://{connectionHostname}/{Connections_AzureApplicationId}"
+   "resource": "api://%Connections_Hostname%/%Connections_AzureApplicationId%"
 },
 ```
 <br>
@@ -233,6 +233,14 @@ A Teams app package is a .zip file containing the following - example shown in F
 ![App Package Zip](./doc/zip-pkg.png)  
 Figure 4: App Package Content
 <br>
+
+The files can be zipped up using your favorite archive utility.  Just ensure that there are no folders contained within the zip files.  All files should be at the root level of the archive.
+
+If you are using a terminal on a Mac or Linux, use something similar to the following:
+
+  ```
+  zip ConnectionsTeamsApp.zip *
+  ```
 
 Once the package is created it can be uploaded to the Teams admin center by an administrator and published for use in the organization apps catalog. 
 

--- a/microsoft-teams/App Manifests/sample/de.json
+++ b/microsoft-teams/App Manifests/sample/de.json
@@ -1,9 +1,0 @@
-{
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.7/MicrosoftTeams.Localization.schema.json",
-    "name.short": "Connections",
-    "name.full": "HCL Connections",
-    "description.short": "HCL Connections für Microsoft Teams",
-    "description.full": "HCL Connections bietet eine kollaborative Plattform, die Ihre Mitarbeiter in Verbindung hält. Mit HCL Connections können Sie ein personalisiertes, gut gestaltetes digitales Büro mit rollenbasierten Inhalten und Tools erstellen, damit sich Ihre Teams auf das Erreichen von Geschäftszielen konzentrieren können. \n\nVerwenden Sie diese App, um auf einfache Weise auf Ihre bevorzugten HCL Connections-Communitys in einem Kanal zuzugreifen. Oder verwenden Sie die Messaging-Erweiterung, um Connections-Inhalte für andere Microsoft Teams-Benutzer in Ihrer Organisation freizugeben.",
-    "composeExtensions[0].commands[0].title": "Connections Teilen",
-    "composeExtensions[0].commands[0].description": "Teilen Sie Connections-Inhalte mit anderen Microsoft Teams-Benutzern"
-}

--- a/microsoft-teams/App Manifests/sample/en.json
+++ b/microsoft-teams/App Manifests/sample/en.json
@@ -3,7 +3,7 @@
     "name.short": "Connections",
     "name.full": "HCL Connections",
     "description.short": "HCL Connections for Microsoft Teams",
-    "description.full": "HCL Connections delivers a collaborative platform that keeps your employees connected and engaged. HCL Connections helps create a personalized, well-designed, digital office with role-based content and tools to keep your teams focused on achieving business goals and objectives. \n\nUse this app to easily access your favorite HCL Connections communities in a channel, or use the Messaging Extension to share Connections content with other Microsoft Teams users in your organization.",
-    "composeExtensions[0].commands[0].title": "Partage de connexions",
+    "description.full": "HCL Connections delivers a collaborative platform that keeps your employees connected and engaged. HCL Connections helps create a personalized, well-designed, digital office with role-based content and tools to keep your teams focused on achieving business goals and objectives.\n\nUse this app to easily access your favorite HCL Connections communities in a channel, or use the Messaging Extension to share Connections content with other Microsoft Teams users in your organization.",
+    "composeExtensions[0].commands[0].title": "Connections Share",
     "composeExtensions[0].commands[0].description": "Share Connections content with other Microsoft Teams users"
 }

--- a/microsoft-teams/App Manifests/sample/fr.json
+++ b/microsoft-teams/App Manifests/sample/fr.json
@@ -1,9 +1,0 @@
-{
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.7/MicrosoftTeams.Localization.schema.json",
-    "name.short": "Connections",
-    "name.full": "HCL Connections",
-    "description.short": "HCL Connections pour Microsoft Teams",
-    "description.full": "HCL Connections propose une plateforme collaborative qui permet à vos employés de rester connectés et engagés. HCL Connections permet de créer un bureau numérique personnalisé et bien conçu avec du contenu et des outils basés sur les rôles pour garder vos équipes concentrées sur la réalisation des buts et objectifs commerciaux. \n\nUtilisez cette application pour accéder facilement à vos communautés HCL Connections préférées dans un canal, ou utilisez l'extension de messagerie pour partager le contenu Connections avec d'autres utilisateurs Microsoft Teams de votre organisation.",
-    "composeExtensions[0].commands[0].title": "Partage de Connections",
-    "composeExtensions[0].commands[0].description": "Partager le contenu de Connections avec d'autres utilisateurs de Microsoft Teams"
-}

--- a/microsoft-teams/App Manifests/sample/manifest.json
+++ b/microsoft-teams/App Manifests/sample/manifest.json
@@ -2,12 +2,14 @@
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.7/MicrosoftTeams.schema.json",
     "manifestVersion": "1.7",
     "version": "1.0.0",
+    "id": "2418645c-c344-4b0e-985a-5ab940309778",
     "packageName": "com.hcl.connections",
     "developer": {
         "name": "HCL",
         "websiteUrl": "https://www.hcltechsw.com/connections",
         "privacyUrl": "https://www.hcltechsw.com/wps/portal/legal/privacy",
-        "termsOfUseUrl": "https://www.hcltechsw.com/wps/portal/legal/terms-use"
+        "termsOfUseUrl": "https://www.hcltechsw.com/wps/portal/legal/terms-use",
+        "mpnId": "1416163"
     },
     "icons": {
         "color": "Connections192x192.png",
@@ -24,7 +26,7 @@
     "accentColor": "#01539B",
     "configurableTabs": [
         {
-            "configurationUrl": "https://{Connections_Hostname}/teams-tab",
+            "configurationUrl": "https://%Connections_Hostname%/teams-tab",
             "canUpdateConfiguration": true,
             "scopes": [
                 "team",
@@ -34,9 +36,10 @@
     ],
     "bots": [
         {
-            "botId": "{Connections_AzureApplicationId}",
+            "botId": "%Connections_AzureApplicationId%",
             "scopes": [
-                "team"
+                "team",
+                "groupchat"
             ],
             "supportsFiles": true,
             "isNotificationOnly": false
@@ -44,7 +47,7 @@
     ],
     "composeExtensions": [
         {
-            "botId": "{Connections_AzureApplicationId}",
+            "botId": "%Connections_AzureApplicationId%",
             "canUpdateConfiguration": true,
             "commands": [
                 {
@@ -70,7 +73,7 @@
                         "title": "Connections Share",
                         "width": "medium",
                         "height": "medium",
-                        "url": "https://{Connections_Hostname}/teams-share-service/api/msteams/command"
+                        "url": "https://%Connections_Hostname%/teams-share-service/api/msteams/command"
                     }
                 }
             ]
@@ -81,11 +84,11 @@
         "messageTeamMembers"
     ],
     "validDomains": [
-        "{Connections_Hostname}"
+        "%Connections_Hostname%"
     ],
     "webApplicationInfo": {
-        "id": "{Connections_AzureApplicationId}",
-        "resource": "api://{connectionHostname}/{Connections_AzureApplicationId}"
+        "id": "%Connections_AzureApplicationId%",
+        "resource": "api://%Connections_Hostname%/%Connections_AzureApplicationId%"
     },
     "localizationInfo": {
         "defaultLanguageTag": "en",
@@ -93,14 +96,6 @@
             {
                 "languageTag": "en",
                 "file": "en.json"
-            },
-            {
-                "languageTag": "fr",
-                "file": "fr.json"
-            },
-            {
-                "languageTag": "de",
-                "file": "de.json"
             }
         ]
     }


### PR DESCRIPTION
Replacing substitution delimiter with "%" versus "{}"
Added groupchat scope to bot
removed all but en language since languages are not integrated yet
